### PR TITLE
Remove a `puts` call

### DIFF
--- a/lib/loops_sdk/contacts.rb
+++ b/lib/loops_sdk/contacts.rb
@@ -16,7 +16,6 @@ module LoopsSdk
           email: email,
           mailingLists: mailing_lists
         }.merge(properties)
-        puts "Contact Data: #{contact_data.inspect}"
         make_request(:put, "v1/contacts/update", {}, contact_data)
       end
 


### PR DESCRIPTION
This probably shouldn't be here as it can potentially leak PII data via logs and isn't configurable (via loggers).

Might be good to test/lint for `puts` and similar calls.